### PR TITLE
Use runtime arguments in Divan benchmarks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,9 +75,9 @@ checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
 name = "divan"
-version = "0.1.8"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf174e1957cfadab3bcb040afb210ea8b7c2ffc094eb88b750be61fc601835e"
+checksum = "5398159ee27f2b123d89b856bad61725442f37df5fb98c30cd570c318d594aee"
 dependencies = [
  "cfg-if",
  "clap",
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "divan-macros"
-version = "0.1.8"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "510ef69263e119c8ec0213761e397d26a3f6d35e13a454549508446d3578ddc0"
+checksum = "5092f66eb3563a01e85552731ae82c04c934ff4efd7ad1a0deae7b948f4b3ec4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ categories = ["science", "simulation", "mathematics"]
 num-traits = "0.2.17"
 
 [dev-dependencies]
-divan = "0.1.8"
+divan = "0.1.11"
 anyhow = "1.0"
 approx = "0.5.1"
 rand = "0.8.5"

--- a/benches/allocating_log_sum_exp.rs
+++ b/benches/allocating_log_sum_exp.rs
@@ -24,26 +24,26 @@ fn get_big_vector_overflow(n: u32) -> Vec<LogProb<f64>> {
 
 const SIZES: &[u32] = &[0, 1, 2, 5, 10, 20, 50, 100, 1000, 10_000];
 
-#[divan::bench(consts = SIZES)]
-fn allocate_log_exp<const N: u32>() -> LogProb<f64> {
-    divan::black_box(get_big_vector(N).into_iter())
+#[divan::bench(args = SIZES)]
+fn allocate_log_exp(n: u32) -> LogProb<f64> {
+    divan::black_box(get_big_vector(n).into_iter())
         .log_sum_exp()
         .unwrap()
 }
 
-#[divan::bench(consts = SIZES)]
-fn dont_allocate_log_exp<const N: u32>() -> LogProb<f64> {
-    divan::black_box(get_big_vector(N).into_iter())
+#[divan::bench(args = SIZES)]
+fn dont_allocate_log_exp(n: u32) -> LogProb<f64> {
+    divan::black_box(get_big_vector(n).into_iter())
         .log_sum_exp_no_alloc()
         .unwrap()
 }
 
-#[divan::bench(consts = SIZES)]
-fn allocate_log_exp_clamped<const N: u32>() -> LogProb<f64> {
-    divan::black_box(get_big_vector_overflow(N).into_iter()).log_sum_exp_clamped()
+#[divan::bench(args = SIZES)]
+fn allocate_log_exp_clamped(n: u32) -> LogProb<f64> {
+    divan::black_box(get_big_vector_overflow(n).into_iter()).log_sum_exp_clamped()
 }
 
-#[divan::bench(consts = SIZES)]
-fn dont_allocate_log_exp_clamped<const N: u32>() -> LogProb<f64> {
-    divan::black_box(get_big_vector_overflow(N).into_iter()).log_sum_exp_clamped_no_alloc()
+#[divan::bench(args = SIZES)]
+fn dont_allocate_log_exp_clamped(n: u32) -> LogProb<f64> {
+    divan::black_box(get_big_vector_overflow(n).into_iter()).log_sum_exp_clamped_no_alloc()
 }


### PR DESCRIPTION
This greatly improves compile times.