### PR TITLE
feat: Implement `Hash`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ keywords = [
 categories = ["science", "simulation", "mathematics"]
 
 [dependencies]
-num-traits = "0.2.19"
-serde = { version = "1.0.219", features = ["serde_derive"] }
+num-traits = "^0.2.19"
+serde = { version = "^1.0.219", features = ["serde_derive"], optional = true }
 
 [dev-dependencies]
 divan = "0.1"
@@ -26,6 +26,10 @@ anyhow = "1.0"
 approx = "0.5.1"
 rand = "0.9"
 rand_chacha = "0.9"
+
+[features]
+# Enable serialization using `serde`
+serde = ["dep:serde"]
 
 [[bench]]
 name = "allocating_log_sum_exp"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,13 +99,13 @@ mod errors;
 pub use errors::{
     FloatIsNanOrPositive, FloatIsNanOrPositiveInfinity, ProbabilitiesSumToGreaterThanOne,
 };
-use serde::{Deserialize, Serialize};
 mod adding;
 mod math;
 mod softmax;
 pub use softmax::{softmax, Softmax};
 
-#[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Default, Serialize, Deserialize)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Debug, Default)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 
 ///Struct that can only hold float values that correspond to negative log
 ///probabilities.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,7 @@
 
 use std::borrow::Borrow;
 
+use core::hash::Hash;
 use num_traits::Float;
 mod errors;
 pub use errors::{
@@ -199,6 +200,12 @@ impl<T: Float> Eq for LogProb<T> {}
 impl<T: Float> Ord for LogProb<T> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.0.partial_cmp(&other.0).unwrap()
+    }
+}
+impl<T: Hash> Hash for LogProb<T>
+{
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.0.hash(state)
     }
 }
 


### PR DESCRIPTION
This PR implements `Hash` for `LogProb` and makes `serde` optional

All `std` trait implementations in this crate like `Borrow` or `Error` can be refactored to `core` as well, and it would make it easy for this crate to be `no_std`.

Resolves #4