### PR TITLE
fix: Implement `Hash` trait for `f32` and `f64`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@
 //! # #[cfg(feature = "alloc")]
 //! let z = [x,y].iter().log_sum_exp().unwrap();
 //! # #[cfg(not(feature = "alloc"))]
-//! let z = [x,y].iter().log_sum_exp_no_alloc().unwrap();
+//! # let z = [x,y].iter().log_sum_exp_no_alloc().unwrap();
 //! assert_eq!(z, LogProb::from_raw_prob(0.75).unwrap());
 //! let v = log_sum_exp(&[x,y]).unwrap();
 //! assert_eq!(z, LogProb::from_raw_prob(0.75).unwrap());
@@ -73,13 +73,13 @@
 //! # #[cfg(feature = "alloc")]
 //! let z = [x,y].iter().log_sum_exp_clamped();
 //! # #[cfg(not(feature = "alloc"))]
-//! let z = [x,y].iter().log_sum_exp_clamped_no_alloc();
+//! # let z = [x,y].iter().log_sum_exp_clamped_no_alloc();
 //! assert_eq!(z, LogProb::new(0.0).unwrap());
 //!
 //! # #[cfg(feature = "alloc")]
 //! let z = [x,y].into_iter().log_sum_exp_float();
 //! # #[cfg(not(feature = "alloc"))]
-//! let z = [x,y].into_iter().log_sum_exp_float_no_alloc();
+//! # let z = [x,y].into_iter().log_sum_exp_float_no_alloc();
 //!
 //! approx::assert_relative_eq!(z, (1.25_f64).ln());
 //!
@@ -129,6 +129,36 @@ pub use softmax::{softmax, Softmax};
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 ///Struct that can only hold float values that correspond to negative log
 ///probabilities.
+///
+///## `Ord` and `Hash`
+///`LogProb` implements both `Hash` and `Ord` since we no longer have `NaN` values.
+///However, one should always remember that floating point numbers won't necessarily correspond to
+///the exact real number that one might expect when doing different mathematical operations.
+///
+/// ```
+/// # #[cfg(feature = "alloc")]
+/// # use std::collections::HashSet;
+/// # #[cfg(feature = "alloc")]
+/// # use std::collections::BTreeSet;
+/// # use logprob::LogProb;
+/// # fn main() -> anyhow::Result<()> {
+/// let a = LogProb::new(-0.1_f64 - 0.2_f64).unwrap();
+/// let b = LogProb::new(-0.3_f64).unwrap();
+///
+/// # #[cfg(feature = "alloc")]
+/// let set = HashSet::from([a, b]);
+/// # #[cfg(feature = "alloc")]
+/// let o_set =BTreeSet::from([a,b]);
+///
+/// //Since the floats aren't exactly equal like one might expect,
+/// //we have 2 elements in both collections
+/// # #[cfg(feature = "alloc")]
+/// assert_eq!(set.len(), 2);
+/// # #[cfg(feature = "alloc")]
+/// assert_eq!(o_set.len(), 2);
+/// # Ok(())
+/// # }
+/// ```
 #[repr(transparent)]
 pub struct LogProb<T>(T);
 pub use adding::{log_sum_exp, log_sum_exp_clamped, log_sum_exp_float, LogSumExp};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,25 +136,25 @@ pub use softmax::{softmax, Softmax};
 ///the exact real number that one might expect when doing different mathematical operations.
 ///
 /// ```
-/// # #[cfg(feature = "alloc")]
+/// # #[cfg(feature = "std")]
 /// # use std::collections::HashSet;
-/// # #[cfg(feature = "alloc")]
+/// # #[cfg(feature = "std")]
 /// # use std::collections::BTreeSet;
 /// # use logprob::LogProb;
 /// # fn main() -> anyhow::Result<()> {
 /// let a = LogProb::new(-0.1_f64 - 0.2_f64).unwrap();
 /// let b = LogProb::new(-0.3_f64).unwrap();
 ///
-/// # #[cfg(feature = "alloc")]
+/// # #[cfg(feature = "std")]
 /// let set = HashSet::from([a, b]);
-/// # #[cfg(feature = "alloc")]
+/// # #[cfg(feature = "std")]
 /// let o_set =BTreeSet::from([a,b]);
 ///
 /// //Since the floats aren't exactly equal like one might expect,
 /// //we have 2 elements in both collections
-/// # #[cfg(feature = "alloc")]
+/// # #[cfg(feature = "std")]
 /// assert_eq!(set.len(), 2);
-/// # #[cfg(feature = "alloc")]
+/// # #[cfg(feature = "std")]
 /// assert_eq!(o_set.len(), 2);
 /// # Ok(())
 /// # }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -234,12 +234,12 @@ impl<T: Float> Ord for LogProb<T> {
 }
 impl Hash for LogProb<f32> {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-      self.0.to_bits().hash(state);
+        self.0.to_bits().hash(state);
     }
 }
 impl Hash for LogProb<f64> {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-      self.0.to_bits().hash(state);
+        self.0.to_bits().hash(state);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -232,9 +232,14 @@ impl<T: Float> Ord for LogProb<T> {
         self.0.partial_cmp(&other.0).unwrap()
     }
 }
-impl<T: Hash> Hash for LogProb<T> {
+impl Hash for LogProb<f32> {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
-        self.0.hash(state);
+      self.0.to_bits().hash(state);
+    }
+}
+impl Hash for LogProb<f64> {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+      self.0.to_bits().hash(state);
     }
 }
 

--- a/tests/integrations.rs
+++ b/tests/integrations.rs
@@ -1,3 +1,6 @@
+use core::f32;
+use std::collections::HashSet;
+
 use anyhow::Result;
 use logprob::{LogProb, LogSumExp};
 
@@ -9,6 +12,18 @@ use alloc::vec::Vec;
 
 #[cfg(feature = "alloc")]
 use logprob::{log_sum_exp, log_sum_exp_clamped, log_sum_exp_float, softmax, Softmax};
+
+#[test]
+fn implements_hash() -> Result<()>
+{
+  let mut table = HashSet::<LogProb<f32>>::new();
+  table.insert(LogProb::new(-0.5_f32)?);
+  table.insert(LogProb::new(-0.8_f32)?);
+  table.insert(LogProb::new(f32::NEG_INFINITY)?);
+
+  assert_eq!(table.len(), 3);
+  Ok(())
+}
 
 #[test]
 fn basic_construction() -> Result<()> {

--- a/tests/integrations.rs
+++ b/tests/integrations.rs
@@ -14,15 +14,14 @@ use alloc::vec::Vec;
 use logprob::{log_sum_exp, log_sum_exp_clamped, log_sum_exp_float, softmax, Softmax};
 
 #[test]
-fn implements_hash() -> Result<()>
-{
-  let mut table = HashSet::<LogProb<f32>>::new();
-  table.insert(LogProb::new(-0.5_f32)?);
-  table.insert(LogProb::new(-0.8_f32)?);
-  table.insert(LogProb::new(f32::NEG_INFINITY)?);
+fn implements_hash() -> Result<()> {
+    let mut table = HashSet::<LogProb<f32>>::new();
+    table.insert(LogProb::new(-0.5_f32)?);
+    table.insert(LogProb::new(-0.8_f32)?);
+    table.insert(LogProb::new(f32::NEG_INFINITY)?);
 
-  assert_eq!(table.len(), 3);
-  Ok(())
+    assert_eq!(table.len(), 3);
+    Ok(())
 }
 
 #[test]


### PR DESCRIPTION
Previous implementation of `Hash` has a problem. That is, `f32` and `f64` both do not have `Hash` due to the existence of NaNs. This PR fixes this problem by hashing their bits.